### PR TITLE
Fix missing settings action bar and normalise definition icon sizes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,9 +16,7 @@
             android:windowSoftInputMode="stateVisible|adjustPan" >
 
             <intent-filter>
-
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/arcuscomputing/dictionary/EditPreferencesActivity.kt
+++ b/app/src/main/java/com/arcuscomputing/dictionary/EditPreferencesActivity.kt
@@ -2,6 +2,7 @@ package com.arcuscomputing.dictionary
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.preference.PreferenceFragmentCompat
 import com.arcuscomputing.dictionarypro.ads.R
 
@@ -9,6 +10,14 @@ class EditPreferencesActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_preferences)
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
     }
 
     class PrefsFragment : PreferenceFragmentCompat() {

--- a/app/src/main/res/drawable/ic_play_arrow.xml
+++ b/app/src/main/res/drawable/ic_play_arrow.xml
@@ -6,5 +6,5 @@
     android:viewportHeight="24">
     <path
         android:fillColor="#FF000000"
-        android:pathData="M8 5v14l11-7z" />
+        android:pathData="M5 3l15 9-15 9V3z" />
 </vector>

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -1,12 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/preferences_container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <fragment
-        android:name="com.arcuscomputing.dictionary.EditPreferencesActivity$PrefsFragment"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="?attr/actionBarSize" />
 
-</FrameLayout>
+    <FrameLayout
+        android:id="@+id/preferences_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <fragment
+            android:name="com.arcuscomputing.dictionary.EditPreferencesActivity$PrefsFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/definition_table.xml
+++ b/app/src/main/res/layout/definition_table.xml
@@ -35,37 +35,34 @@
 
             <ImageView
                 android:id="@+id/ShareIcon"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:layout_marginStart="4dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:clickable="true"
                 android:contentDescription="@string/click_to_share"
                 android:focusable="true"
-                android:padding="8dp"
+                android:padding="12dp"
                 android:src="@drawable/ic_share"
                 app:tint="?attr/colorOnSurfaceVariant" />
 
             <ImageView
                 android:id="@+id/TtsIcon"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:layout_marginStart="4dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:clickable="true"
                 android:contentDescription="@string/click_to_hear_definition"
                 android:focusable="true"
-                android:padding="8dp"
+                android:padding="12dp"
                 android:src="@drawable/ic_play_arrow"
                 app:tint="?attr/colorOnSurfaceVariant" />
 
             <ImageView
                 android:id="@+id/FavIcon"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:layout_marginStart="4dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:clickable="true"
                 android:contentDescription="@string/click_to_add_to_favourites"
                 android:focusable="true"
-                android:padding="8dp"
+                android:padding="12dp"
                 android:src="@drawable/ic_star_border"
                 app:tint="?attr/colorOnSurfaceVariant" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
+        classpath 'com.android.tools.build:gradle:9.2.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,13 @@
 android.useAndroidX=true
 android.enableJetifier=false
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 include ':app'


### PR DESCRIPTION
## Summary
- **Settings action bar**: Added `MaterialToolbar` to the preferences screen layout and wired it up in `EditPreferencesActivity` with `setSupportActionBar` + a back-navigation handler — fixing the pre-existing missing action bar.
- **Icon sizing**: Standardised the share/play/favourite `ImageView`s on definition cards to 48dp touch targets with 12dp padding, matching Material Design system defaults (previously 40dp/8dp).
- **Play icon path**: Expanded the play-arrow vector path from `M8 5v14l11-7z` to `M5 3l15 9-15 9V3z` so it visually fills its viewport as well as the share and star icons do, removing the apparent size mismatch between the three icons.
- **Gradle**: Upgraded wrapper, AGP, and Kotlin plugin versions.

## Test plan
- [ ] Open Settings — confirm action bar appears with title and a working back (←) button
- [ ] Search for a word — confirm share, play, and favourite icons on definition cards appear the same visual size
- [ ] Tap each icon — confirm share, TTS playback, and favourite toggle all still work correctly
- [ ] Verify the app builds cleanly against the updated Gradle versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)