### PR TITLE
Replace ArcusDictionary @Synchronized with a private dispatcher

### DIFF
--- a/app/src/main/java/com/arcuscomputing/dictionary/ArcusSearchActivity.kt
+++ b/app/src/main/java/com/arcuscomputing/dictionary/ArcusSearchActivity.kt
@@ -110,7 +110,7 @@ class ArcusSearchActivity : AppCompatActivity(),
             .setCancelable(false)
             .show()
         lifecycleScope.launch {
-            withContext(Dispatchers.IO) { dictionary.ensureLoaded() }
+            dictionary.ensureLoaded()
             progress?.dismiss()
             progress = null
         }
@@ -147,9 +147,7 @@ class ArcusSearchActivity : AppCompatActivity(),
             rvResults.adapter = emptyAdapter()
             return
         }
-        val results = withContext(Dispatchers.IO) {
-            dictionary.getMatches(q, preferences.isPureAlpha)
-        }
+        val results = dictionary.getMatches(q, preferences.isPureAlpha)
         val favourites = withContext(Dispatchers.IO) { dbHelper.getFavouriteKeys() }
         rvResults.adapter = QuickResultListAdapter(results, favourites, false, this)
         if (results.isEmpty()) {

--- a/app/src/main/java/com/arcuscomputing/dictionary/io/ArcusDictionary.kt
+++ b/app/src/main/java/com/arcuscomputing/dictionary/io/ArcusDictionary.kt
@@ -2,6 +2,9 @@ package com.arcuscomputing.dictionary.io
 
 import com.arcuscomputing.dictionary.PartOfSpeech
 import com.arcuscomputing.dictionary.WordModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.IOException
 
@@ -11,16 +14,20 @@ private const val QUICK_MAX_TO_RETURN = 40
 
 class ArcusDictionary(private val dataFileManager: DataFileManager) {
 
+    // Single-threaded dispatcher serialises all access to the RandomAccessFile
+    // pair below, so the mutable seek state can't race across coroutines.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = Dispatchers.IO.limitedParallelism(1)
+
     private var loaded = false
     private var indexRaf: ReadRandom? = null
     private var definitionsRaf: ReadRandom? = null
 
-    @Synchronized
-    fun ensureLoaded() {
-        if (loaded) return
+    suspend fun ensureLoaded() = withContext(dispatcher) {
+        if (loaded) return@withContext
         if (!dataFileManager.ensureExtracted()) {
             Timber.e("Failed to extract dictionary data files")
-            return
+            return@withContext
         }
         try {
             indexRaf = ReadRandom(dataFileManager.indexFile, "r")
@@ -31,9 +38,8 @@ class ArcusDictionary(private val dataFileManager: DataFileManager) {
         }
     }
 
-    @Synchronized
-    fun getMatches(query: String, pureAlphaSort: Boolean): List<WordModel> {
-        if (query.length < 2 || !loaded) return emptyList()
+    suspend fun getMatches(query: String, pureAlphaSort: Boolean): List<WordModel> = withContext(dispatcher) {
+        if (query.length < 2 || !loaded) return@withContext emptyList()
 
         val list = mutableListOf<WordModel>()
         val q = query.lowercase().trim()
@@ -79,7 +85,7 @@ class ArcusDictionary(private val dataFileManager: DataFileManager) {
             Timber.e(e, "Unexpected error in getMatches")
         }
 
-        return prepareResults(list, q, pureAlphaSort)
+        prepareResults(list, q, pureAlphaSort)
     }
 
     private fun addResultToList(line: String, list: MutableList<WordModel>, defsRandom: ReadRandom) {


### PR DESCRIPTION
Stacked on top of #8.

## Summary
- `ArcusDictionary.ensureLoaded` and `getMatches` are now `suspend` functions; each one wraps its body in `withContext(dispatcher)` where `dispatcher = Dispatchers.IO.limitedParallelism(1)`.
- The single-threaded dispatcher serialises every call to the underlying `RandomAccessFile` pair, so the mutable seek state can't race across concurrent searches even when an in-flight search hasn't yet observed cancellation.
- `@Synchronized` (and the JVM monitor lock that came with it) drops out of both methods.
- `ArcusSearchActivity` no longer wraps dictionary calls in `withContext(Dispatchers.IO)` — the dictionary now picks its own context. The `dbHelper.getFavouriteKeys()` wrapper stays put: it isn't part of this concurrency boundary.

`@Synchronized` on `FavouritesDbHelper` was already removed in #8 — `SQLiteDatabase` handles its own internal locking.

## Test plan
- [x] `./gradlew assembleDebug` passes locally.
- [x] Type a query rapidly enough to cancel-and-reissue several times — results match the final query, no crashes.
- [x] Cold launch still shows the init dialog and dismisses it.
- [x] Search → favourites → back → search returns the same result list as before.

## Note on base branch
This PR targets `baz8080/cleanup-pass-1` so the diff stays focused. Once #8 lands on master, GitHub will retarget this one to master automatically; alternatively rebase + force-push if you'd prefer to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)